### PR TITLE
Port from WebKit to WebKit2

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -20,11 +20,11 @@
 
 import gi
 gi.require_version("Gtk", "3.0")
-gi.require_version("WebKit", "3.0")
+gi.require_version("WebKit2", "4.0")
 
 from gi.repository import Gtk
 from gi.repository import GLib
-from gi.repository import WebKit
+from gi.repository import WebKit2
 from gi.repository import GObject
 
 
@@ -39,17 +39,17 @@ class Browser(Gtk.ScrolledWindow):
     def __init__(self):
         Gtk.ScrolledWindow.__init__(self)
 
-        self.browser = WebKit.WebView()
-        self.browser.connect("load-finished", self.__load_finished)
+        self.browser = WebKit2.WebView()
+        self.browser.connect("web_process_terminated", self.__web_process_terminated_cb)
         self.add(self.browser)
 
         self.show_all()
 
-    def __load_finished(self, view, frame):
+    def __web_process_terminated_cb(self, view, frame):
         source = frame.get_data_source()
         data = source.get_data()
         if data is not None:
             self.emit("load-finished", data.str)
 
     def open(self, url):
-        GLib.idle_add(self.browser.open, url)
+        GLib.idle_add(self.browser.load_uri, url)

--- a/login_screen.py
+++ b/login_screen.py
@@ -42,13 +42,13 @@ class LoginScreen(Gtk.VBox):
         Gtk.VBox.__init__(self)
 
         self.browser = Browser()
-        self.browser.connect("load-finished", self._load_finished_cb)
+        self.browser.connect("web_process_terminated", self._web_process_terminated_cb)
         self.pack_start(self.browser, True, True, 10)
 
-    def _load_finished_cb(self, browser, html):
+    def _web_process_terminated_cb(self, browser, html):
         if "<title>Success code=" in html:
             code = re.search(r"<title>Success code=(.+)</title>", html).group(1)
             self.emit("send-code", code)
 
     def set_url(self, url):
-        self.browser.open(url)
+        self.browser.load_uri(url)

--- a/mail_viewer.py
+++ b/mail_viewer.py
@@ -27,11 +27,11 @@ from utils import get_date_string
 
 import gi
 gi.require_version("Gtk", "3.0")
-gi.require_version("WebKit", "3.0")
+gi.require_version("WebKit2", "4.0")
 
 from gi.repository import Gtk
 from gi.repository import Pango
-from gi.repository import WebKit
+from gi.repository import WebKit2
 from gi.repository import GObject
 
 
@@ -127,7 +127,7 @@ class MailBox(Gtk.VBox):
         self.mailbox = Gtk.VBox()
         self.pack_start(self.mailbox, False, False, 0)
 
-        view = WebKit.WebView()
+        view = WebKit2.WebView()
         self.mailbox.pack_start(view, False, False, 0)
 
         if self.message_html is not None:
@@ -144,7 +144,7 @@ class MailBox(Gtk.VBox):
             extra_expander.set_label("...")
             self.extrabox.pack_start(extra_expander, False, False, 0)
 
-            view = WebKit.WebView()
+            view = WebKit2.WebView()
             view.set_size_request(1, 1)
             view.load_html_string(self.extra_html, "file:///")
             extra_expander.add(view)


### PR DESCRIPTION
### Explanation
Fix #27. This PR ports from WebKit to WebKit2. 

### Reason
The WebKit API version 3.0 is deprecated and activities still using it throws a lot of PyGI errors, port this activity to the WebKit2 4.0 API. 

### TODO
- [ ] Test (Don't know how to finish login, it asks me to copy a code that gmail gives me to the application, but I have no idea where to copy it).