### PR TITLE
Fix send button

### DIFF
--- a/redactor.py
+++ b/redactor.py
@@ -543,4 +543,5 @@ class Redactor(Gtk.VBox):
                 mail["threadId"] = info["threadid"]
 
         mail["raw"] = base64.urlsafe_b64encode(message.as_string())
+        mail["raw"] = mail["raw"].decode()
         self.emit("send", mail)


### PR DESCRIPTION
In Gmail activity clicking on "Send" button (tested by send it to only one person) throws an error.
In this PR I tried to fix the above mentioned error.
Fixes #17 