### PR TITLE
Port from WebKit to WebKit2

### DIFF
--- a/browser.py
+++ b/browser.py
@@ -40,7 +40,7 @@ class Browser(Gtk.ScrolledWindow):
         Gtk.ScrolledWindow.__init__(self)
 
         self.browser = WebKit2.WebView()
-        self.browser.connect("web_process_terminated", self.__web_process_terminated_cb)
+        self.browser.connect("web-process-terminated", self.__web_process_terminated_cb)
         self.add(self.browser)
 
         self.show_all()

--- a/browser.py
+++ b/browser.py
@@ -20,11 +20,11 @@
 
 import gi
 gi.require_version("Gtk", "3.0")
-gi.require_version("WebKit", "3.0")
+gi.require_version("WebKit2", "4.0")
 
 from gi.repository import Gtk
 from gi.repository import GLib
-from gi.repository import WebKit
+from gi.repository import WebKit2
 from gi.repository import GObject
 
 
@@ -45,11 +45,11 @@ class Browser(Gtk.ScrolledWindow):
 
         self.show_all()
 
-    def __load_finished(self, view, frame):
+    def __web_process_terminated_cb(self, view, frame):
         source = frame.get_data_source()
         data = source.get_data()
         if data is not None:
             self.emit("load-finished", data.str)
 
     def open(self, url):
-        GLib.idle_add(self.browser.open, url)
+        GLib.idle_add(self.browser.load_uri, url)

--- a/login_screen.py
+++ b/login_screen.py
@@ -42,7 +42,7 @@ class LoginScreen(Gtk.VBox):
         Gtk.VBox.__init__(self)
 
         self.browser = Browser()
-        self.browser.connect("web_process_terminated", self._web_process_terminated_cb)
+        self.browser.browser.connect("web-process-terminated", self._web_process_terminated_cb)
         self.pack_start(self.browser, True, True, 10)
 
     def _web_process_terminated_cb(self, browser, html):
@@ -51,4 +51,4 @@ class LoginScreen(Gtk.VBox):
             self.emit("send-code", code)
 
     def set_url(self, url):
-        self.browser.load_uri(url)
+        self.browser.browser.load_uri(url)

--- a/login_screen.py
+++ b/login_screen.py
@@ -45,7 +45,7 @@ class LoginScreen(Gtk.VBox):
         self.browser.browser.connect("web-process-terminated", self._web_process_terminated_cb)
         self.pack_start(self.browser, True, True, 10)
 
-    def _load_finished_cb(self, browser, html):
+    def _web_process_terminated_cb(self, browser, html):
         if "<title>Success code=" in html:
             code = re.search(r"<title>Success code=(.+)</title>", html).group(1)
             self.emit("send-code", code)


### PR DESCRIPTION
### Explanation
Fixes #27 and #30. This PR ports from WebKit to WebKit2. 

### Reason
The WebKit API version 3.0 is deprecated and activities still using it throws a lot of PyGI errors, port this activity to the WebKit2 4.0 API.

### Test result
No error related to the port from WebKit to WebKit2 
```
tonadev@TDPC:~/Documents/Work/OpenSource/code_in/sugarlabs/gmail-activity$ sugar-activity

(sugar-activity:8873): Gtk-WARNING **: 20:48:44.109: Theme parsing error: gtk-widgets.css:16:32: The style property GtkExpander:expander-size is deprecated and shouldn't be used anymore. It will be removed in a future version

(sugar-activity:8873): Gtk-WARNING **: 20:48:44.109: Theme parsing error: gtk-widgets.css:17:35: The style property GtkExpander:expander-spacing is deprecated and shouldn't be used anymore. It will be removed in a future version
/home/tonadev/Documents/Work/OpenSource/code_in/sugarlabs/gmail-activity/oauth2client/_helpers.py:255: UserWarning: Cannot access /home/tonadev/.gmail-credentials.json: No such file or directory
  warnings.warn(_MISSING_FILE_MESSAGE.format(filename))

```


###### Feel free to ask me to solve what I broke
